### PR TITLE
Fix Alea::Random default type

### DIFF
--- a/src/tensor/internal/random.cr
+++ b/src/tensor/internal/random.cr
@@ -24,11 +24,11 @@
 require "alea"
 
 class Num::Rand
-  class_getter generator = Alea::Random.new
+  class_getter generator = Alea::Random(Alea::XSR128).new
   class_getter stdlib_generator = Random.new
 
   def self.set_seed(seed)
-    @@generator = Alea::Random.new(seed)
+    @@generator = Alea::Random(Alea::XSR128).new(seed)
     @@stdlib_generator = Random.new(seed)
   end
 end


### PR DESCRIPTION
I have introduced a couple of breaking changes in [alea](https://github.com/nin93/alea) ([#9](https://github.com/nin93/alea/pull/9)).
Here is a fix for the project!