### PR TITLE
Surround OpenCL test with flag check

### DIFF
--- a/spec/tensor/math_spec.cr
+++ b/spec/tensor/math_spec.cr
@@ -102,7 +102,10 @@ macro test_builtin(fn)
 end
 
 describe Tensor do
-  test_unary_operator :-, :opencl
+  {% if flag?(:opencl) %}
+    test_unary_operator :-, :opencl
+  {% end %}
+
   test_unary_operator :-
 
   test_operator :+


### PR DESCRIPTION
@christopherzimmerman, here's the fix to surround the OpenCL test with a flag check.   