### PR TITLE
Support grad backprop when add/sub use broadcast

### DIFF
--- a/spec/grad/gates_arithmetic_spec.cr
+++ b/spec/grad/gates_arithmetic_spec.cr
@@ -82,6 +82,60 @@ describe Num::Grad do
     end
   {% end %}
 
+  it "backpropogates for addition with broadcast" do
+    ctx = Num::Grad::Context(Float32Tensor).new
+
+    a = ctx.variable([
+      [1_f32, 2_f32, 3_f32, 4_f32],
+      [5_f32, 6_f32, 7_f32, 8_f32],
+      [9_f32, 10_f32, 11_f32, 12_f32],
+      [13_f32, 14_f32, 15_f32, 16_f32],
+    ])
+    b = ctx.variable([
+      1_f32, 1_f32, 1_f32, 1_f32,
+    ])
+
+    result = a + b
+    result.backprop
+
+    expected_a = [[1_f32, 1_f32, 1_f32, 1_f32],
+                  [1_f32, 1_f32, 1_f32, 1_f32],
+                  [1_f32, 1_f32, 1_f32, 1_f32],
+                  [1_f32, 1_f32, 1_f32, 1_f32]].to_tensor
+    expected_b = [4_f32, 4_f32, 4_f32, 4_f32].to_tensor
+
+    Num::Testing.tensor_equal(a.grad, expected_a).should be_true
+    Num::Testing.tensor_equal(b.grad, expected_b).should be_true
+  end
+
+  {% if flag?(:opencl) %}
+    it "backpropogates for addition with broadcast opencl", tags: "opencl" do
+      ctx = Num::Grad::Context(Float32ClTensor).new
+
+      a = ctx.variable([
+        [1_f32, 2_f32, 3_f32, 4_f32],
+        [5_f32, 6_f32, 7_f32, 8_f32],
+        [9_f32, 10_f32, 11_f32, 12_f32],
+        [13_f32, 14_f32, 15_f32, 16_f32],
+      ].to_tensor(OCL))
+      b = ctx.variable([
+        1_f32, 1_f32, 1_f32, 1_f32,
+      ].to_tensor(OCL))
+
+      result = a + b
+      result.backprop
+
+      expected_a = [[1_f32, 1_f32, 1_f32, 1_f32],
+                    [1_f32, 1_f32, 1_f32, 1_f32],
+                    [1_f32, 1_f32, 1_f32, 1_f32],
+                    [1_f32, 1_f32, 1_f32, 1_f32]].to_tensor
+      expected_b = [4_f32, 4_f32, 4_f32, 4_f32].to_tensor
+
+      Num::Testing.tensor_equal(a.grad.cpu, expected_a).should be_true
+      Num::Testing.tensor_equal(b.grad.cpu, expected_b).should be_true
+    end
+  {% end %}
+
   it "backpropogates for subtraction" do
     ctx = Num::Grad::Context(Float32Tensor).new
 
@@ -109,6 +163,60 @@ describe Num::Grad do
       expected = [1_f32].to_tensor
 
       Num::Testing.tensor_equal(a.grad.cpu, expected).should be_true
+    end
+  {% end %}
+
+  it "backpropogates for subtraction with broadcast" do
+    ctx = Num::Grad::Context(Float32Tensor).new
+
+    a = ctx.variable([
+      [1_f32, 2_f32, 3_f32, 4_f32],
+      [5_f32, 6_f32, 7_f32, 8_f32],
+      [9_f32, 10_f32, 11_f32, 12_f32],
+      [13_f32, 14_f32, 15_f32, 16_f32],
+    ])
+    b = ctx.variable([
+      1_f32, 1_f32, 1_f32, 1_f32,
+    ])
+
+    result = a - b
+    result.backprop
+
+    expected_a = [[1_f32, 1_f32, 1_f32, 1_f32],
+                  [1_f32, 1_f32, 1_f32, 1_f32],
+                  [1_f32, 1_f32, 1_f32, 1_f32],
+                  [1_f32, 1_f32, 1_f32, 1_f32]].to_tensor
+    expected_b = [-4_f32, -4_f32, -4_f32, -4_f32].to_tensor
+
+    Num::Testing.tensor_equal(a.grad, expected_a).should be_true
+    Num::Testing.tensor_equal(b.grad, expected_b).should be_true
+  end
+
+  {% if flag?(:opencl) %}
+    it "backpropogates for subtraction with broadcast opencl", tags: "opencl" do
+      ctx = Num::Grad::Context(Float32ClTensor).new
+
+      a = ctx.variable([
+        [1_f32, 2_f32, 3_f32, 4_f32],
+        [5_f32, 6_f32, 7_f32, 8_f32],
+        [9_f32, 10_f32, 11_f32, 12_f32],
+        [13_f32, 14_f32, 15_f32, 16_f32],
+      ].to_tensor(OCL))
+      b = ctx.variable([
+        1_f32, 1_f32, 1_f32, 1_f32,
+      ].to_tensor(OCL))
+
+      result = a - b
+      result.backprop
+
+      expected_a = [[1_f32, 1_f32, 1_f32, 1_f32],
+                    [1_f32, 1_f32, 1_f32, 1_f32],
+                    [1_f32, 1_f32, 1_f32, 1_f32],
+                    [1_f32, 1_f32, 1_f32, 1_f32]].to_tensor
+      expected_b = [-4_f32, -4_f32, -4_f32, -4_f32].to_tensor
+
+      Num::Testing.tensor_equal(a.grad.cpu, expected_a).should be_true
+      Num::Testing.tensor_equal(b.grad.cpu, expected_b).should be_true
     end
   {% end %}
 

--- a/src/grad/backends/agnostic.cr
+++ b/src/grad/backends/agnostic.cr
@@ -24,14 +24,39 @@
 module Num::Grad
   extend self
 
-  # :nodoc:
-  def add_backward(gradient : U) : Array(U) forall U
-    [gradient, gradient]
+  #
+  # This returns the appropriate backward gradient processing for
+  # addition and subtraction based on the
+  # size and rank of the two variables
+  #
+  private def sum_grad_backward(gradient : U, a : U, b : U) : Array(U) forall U
+    # if a.size == 1 || b.size == 1
+    #   # broadcast of 1 element, sum it all up
+    #   gless = U.new([1]) { gradient.sum }
+    #   b.size == 1 ? [gradient, gless] : [gless, gradient]
+    if a.rank != b.rank
+      # broadcast along an axis, so sum dwn by axis
+      swap = a.rank > b.rank
+      gless = gradient
+      (b.rank - a.rank).abs.times do
+        gless = gless.sum(0)
+      end
+      swap ? [gradient, gless] : [gless, gradient]
+    else
+      [gradient, gradient]
+    end
   end
 
   # :nodoc:
-  def subtract_backward(gradient : U) : Array(U) forall U
-    [gradient, gradient * -1]
+  def add_backward(gradient : U, a : Variable(U), b : Variable(U)) : Array(U) forall U
+    sum_grad_backward(gradient, a.value, b.value)
+  end
+
+  # :nodoc:
+  def subtract_backward(gradient : U, a : Variable(U), b : Variable(U)) : Array(U) forall U
+    r = sum_grad_backward(gradient, a.value, b.value)
+    r[1] = -r[1]
+    r
   end
 
   # :nodoc:

--- a/src/grad/variable.cr
+++ b/src/grad/variable.cr
@@ -62,7 +62,7 @@ class Num::Grad::Variable(T)
   # f = a + b # => [5.0]
   # f.backprop
   # ```
-  operator_op :+, Num::Grad::AddGate(T)
+  operator_op :+, Num::Grad::AddGate(T), self, other
 
   # Subtracts a variable from another variable and stores
   # the derivative of the operation in the computational
@@ -83,7 +83,7 @@ class Num::Grad::Variable(T)
   # f = a - b # => [-1.0]
   # f.backprop
   # ```
-  operator_op :-, Num::Grad::SubtractGate(T)
+  operator_op :-, Num::Grad::SubtractGate(T), self, other
 
   # Multiples a variable to another variable and stores
   # the derivative of the operation in the computational


### PR DESCRIPTION
@christopherzimmerman, this fixes grad backpropagation for addition/subtraction when broadcast occurs because one operand has a different rank than the other. 

* Modified Add/Sub gates to sub-class the `TwoOpGate`
* Made `TwoOpGate` an abstract class with `#backward` abstract method (since every subclass has to implement this method)
* Modified operator +/- definition to pass in the operands 
* Modified add/sub backward methods to accept operands
* Add a private convenience method to backprop the add/sub gradient 
  * I originally had a faster case for handling scalar add/sum, but had to remove it until a future time when `Tensor#sum` has OCL implementation. I'm not sure 
  * Let me know if there's a faster way to implement the rank-by-rank sum that I'm using iteratively.

I've included tests, which are based on results I get from PyTorch.